### PR TITLE
Fix C-a spacebar to not quit tmux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -40,7 +40,7 @@ bind-key C-c new-window
 bind-key C-d detach-client
 bind-key k kill-window
 bind-key C-k kill-window
-bind-key \   kill-session
+bind-key \\  kill-session
 
 # Alternate bind for new-window, <prefix>-t defaults to clock.
 unbind-key t


### PR DESCRIPTION
The screen equivalent is C-a backslash, which I believe is wrongly escaped here. Replacing with double backslash appears to resolve the problem.